### PR TITLE
Fix deleting the overlay after every command

### DIFF
--- a/fancy-dabbrev.el
+++ b/fancy-dabbrev.el
@@ -350,7 +350,8 @@ nil."
 (defun fancy-dabbrev--pre-command-hook ()
   "[internal] Function run from `pre-command-hook'."
   (when fancy-dabbrev--preview-overlay
-    (delete-overlay fancy-dabbrev--preview-overlay)))
+    (delete-overlay fancy-dabbrev--preview-overlay)
+    (setq fancy-dabbrev--preview-overlay nil)))
 
 (defun fancy-dabbrev--post-command-hook ()
   "[internal] Function run from `post-command-hook'."


### PR DESCRIPTION
Set the overlay to nil after deleting it,
so checking if it's non-nil is a valid way to know if it exists.

---

Once the overlay had been set `delete-overlay` was running after every command.