### PR TITLE
Set the timer to nil when canceling

### DIFF
--- a/fancy-dabbrev.el
+++ b/fancy-dabbrev.el
@@ -355,7 +355,8 @@ nil."
 (defun fancy-dabbrev--post-command-hook ()
   "[internal] Function run from `post-command-hook'."
   (when (timerp fancy-dabbrev--preview-timer)
-    (cancel-timer fancy-dabbrev--preview-timer))
+    (cancel-timer fancy-dabbrev--preview-timer)
+    (setq fancy-dabbrev--preview-timer nil))
   (unless (fancy-dabbrev--is-fancy-dabbrev-command this-command)
     (fancy-dabbrev--on-exit))
   (when (and fancy-dabbrev-mode


### PR DESCRIPTION
Without this change, cancel-timer was running every time,
after the timer was set (at least once).

Set to nil so `cancel-timer` isn't running in a way that's misleading.