### PR TITLE
Simplify the expandability check

### DIFF
--- a/fancy-dabbrev.el
+++ b/fancy-dabbrev.el
@@ -393,16 +393,17 @@ previous expansion candidate in the menu."
   "[internal] Return non-nil if point is after something to expand."
   (cl-case fancy-dabbrev-expansion-context
     (after-symbol
-     (looking-at (rx symbol-end)))
+     (thing-at-point 'symbol))
     (after-symbol-or-space
-     (or (looking-at (rx (or symbol-end bol)))
-         (string-match-p (rx blank) (char-to-string (char-after (1- (point)))))))
+     (and (not (eq (point) (line-beginning-position)))
+          (save-excursion
+            (re-search-backward
+             "[^[:space:]]" (line-beginning-position) 'noerror)
+            (thing-at-point 'symbol))))
     (after-non-space
-     (string-match-p "[^[:space:]]" (char-to-string (char-after (1- (point))))))
+     (looking-back "[^[:space:]]" (line-beginning-position)))
     (almost-everywhere
-     (not (string-match-p "^[[:space:]]*$" (buffer-substring-no-properties
-                                            (line-beginning-position)
-                                            (point)))))))
+     (looking-back "[^[:space:]] *" (line-beginning-position)))))
 
 (defun fancy-dabbrev--in-previewable-context ()
   "[internal] Return non-nil if point is in a previewable context."

--- a/fancy-dabbrev.el
+++ b/fancy-dabbrev.el
@@ -393,17 +393,16 @@ previous expansion candidate in the menu."
   "[internal] Return non-nil if point is after something to expand."
   (cl-case fancy-dabbrev-expansion-context
     (after-symbol
-     (thing-at-point 'symbol))
+     (looking-at (rx symbol-end)))
     (after-symbol-or-space
-     (and (not (eq (point) (line-beginning-position)))
-          (save-excursion
-            (re-search-backward
-             "[^[:space:]]" (line-beginning-position) 'noerror)
-            (thing-at-point 'symbol))))
+     (or (looking-at (rx (or symbol-end bol)))
+         (string-match-p (rx blank) (char-to-string (char-after (1- (point)))))))
     (after-non-space
-     (looking-back "[^[:space:]]" (line-beginning-position)))
+     (string-match-p "[^[:space:]]" (char-to-string (char-after (1- (point))))))
     (almost-everywhere
-     (looking-back "[^[:space:]] *" (line-beginning-position)))))
+     (not (string-match-p "^[[:space:]]*$" (buffer-substring-no-properties
+                                            (line-beginning-position)
+                                            (point)))))))
 
 (defun fancy-dabbrev--in-previewable-context ()
   "[internal] Return non-nil if point is in a previewable context."

--- a/fancy-dabbrev.el
+++ b/fancy-dabbrev.el
@@ -391,28 +391,29 @@ previous expansion candidate in the menu."
 
 (defun fancy-dabbrev--looking-back-at-expandable ()
   "[internal] Return non-nil if point is after something to expand."
-  (cond ((eq fancy-dabbrev-expansion-context 'after-symbol)
-         (thing-at-point 'symbol))
-        ((eq fancy-dabbrev-expansion-context 'after-symbol-or-space)
-         (and (not (eq (point) (line-beginning-position)))
-              (save-excursion
-                (re-search-backward
-                 "[^[:space:]]" (line-beginning-position) 'noerror)
-                (thing-at-point 'symbol))))
-        ((eq fancy-dabbrev-expansion-context 'after-non-space)
-         (looking-back "[^[:space:]]" (line-beginning-position)))
-        ((eq fancy-dabbrev-expansion-context 'almost-everywhere)
-         (looking-back "[^[:space:]] *" (line-beginning-position)))))
+  (cl-case fancy-dabbrev-expansion-context
+    (after-symbol
+     (thing-at-point 'symbol))
+    (after-symbol-or-space
+     (and (not (eq (point) (line-beginning-position)))
+          (save-excursion
+            (re-search-backward
+             "[^[:space:]]" (line-beginning-position) 'noerror)
+            (thing-at-point 'symbol))))
+    (after-non-space
+     (looking-back "[^[:space:]]" (line-beginning-position)))
+    (almost-everywhere
+     (looking-back "[^[:space:]] *" (line-beginning-position)))))
 
 (defun fancy-dabbrev--in-previewable-context ()
   "[internal] Return non-nil if point is in a previewable context."
-  (cond ((eq fancy-dabbrev-preview-context 'at-eol)
-         (looking-at "[[:space:]]*$"))
-        ((eq fancy-dabbrev-preview-context 'before-non-word)
-         (looking-at "$\\|[^[:word:]_]"))
-        ((eq fancy-dabbrev-preview-context 'everywhere)
-         t)
-        (t nil)))
+  (cl-case fancy-dabbrev-preview-context
+    (at-eol
+     (looking-at "[[:space:]]*$"))
+    (before-non-word
+     (looking-at "$\\|[^[:word:]_]"))
+    (everywhere
+     t)))
 
 (defun fancy-dabbrev--is-fancy-dabbrev-command (command)
   "[internal] Return non-nil if COMMAND is a fancy-dabbrev command."


### PR DESCRIPTION
Hello, thank you for creating this nice package. I am currently exploring its features. 

I noticed that some of the code can be simplified. Please have a look at this PR and consider it. Below is a summary:

- You can use `cl-ecase` instead of the combination of `cond` and `eq`.
- `after-symbol` doesn't seem to work as I expected. I think this should be `(looking-at (rx symbol-end))`.
- `looking-back` is slow, so it should be avoided wherever possible.